### PR TITLE
Disable localhost testing and clean up debug logs

### DIFF
--- a/app/lib/api-client.ts
+++ b/app/lib/api-client.ts
@@ -1,7 +1,7 @@
 // API client for PLC Copilot backend
 // Supports both localhost (development) and production (render.com) endpoints
 
-// Testing mode - set to true to enable localhost health checks in development
+// Testing mode - set to false to use production backend (CORS now fixed)
 const ENABLE_LOCALHOST_TESTING = false;
 
 interface ProjectContext {


### PR DESCRIPTION
- Set ENABLE_LOCALHOST_TESTING to false to use production backend
- Remove verbose console debugging logs
- Backend CORS has been fixed to allow production domain
- Frontend now connects to https://plc-copilot.onrender.com by default